### PR TITLE
`redis-clustering` support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,42 +12,73 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['2.4', '2.5', '2.6', '2.7', '3.0', jruby-head, truffleruby-head]
-        redis: ['4']
-        search: [['opensearch-ruby:2.1.0', 'opensearchproject/opensearch:2.2.1']]
-        include:
-          # Redis 3
-          - ruby: '2.7'
-            redis: '3'
-            search: ['opensearch-ruby:2.1.0', 'opensearchproject/opensearch:2.2.1']
-          # Opensearch 1.0
-          - ruby: '2.7'
-            redis: '4'
-            search: ['opensearch-ruby:1.0.1', 'opensearchproject/opensearch:1.0.1']
-          # Elasticsearch 7.13
-          - ruby: '2.7'
-            redis: '4'
-            search: ['elasticsearch:7.13.3', 'elasticsearch:7.13.4']
-          # Redis 5
-          - ruby: '2.7'
-            redis: '5'
-            search: ['opensearch-ruby:2.1.0', 'opensearchproject/opensearch:2.2.1']
-          # Ruby 2.3 & Elasticsearch 7.5
+        ruby: ['2.3', '2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2', '3.3', '3.4', head, jruby-head, truffleruby-head]
+        redis: ['4', '5']
+        redis_cluster: [false, true]
+        search: [
+          ['opensearch-ruby:2', 'opensearchproject/opensearch:2'],
+          ['opensearch-ruby:3', 'opensearchproject/opensearch:3'],
+          ['elasticsearch:8', 'elasticsearch:8.18.2'],
+          ['elasticsearch:9', 'elasticsearch:9.0.2']
+        ]
+        exclude:
+          # redis 5.x requires ruby >= 2.5
           - ruby: '2.3'
-            redis: '4'
-            search: ['elasticsearch:7.5.0', 'elasticsearch:7.13.4']
+            redis: '5'
+          - ruby: '2.4'
+            redis: '5'
+          # redis-clustering first release is 5.x
+          - redis: '4'
+            redis_cluster: true
+          # redis-clustering 5.x requires ruby >= 2.7
+          - ruby: '2.3'
+            redis_cluster: true
+          - ruby: '2.4'
+            redis_cluster: true
+          - ruby: '2.5'
+            redis_cluster: true
+          - ruby: '2.6'
+            redis_cluster: true
+          # our usage of redis-cluster-client suffers from https://bugs.ruby-lang.org/issues/18991 in ruby <= 3.0
+          - ruby: '2.7'
+            redis_cluster: true
+          - ruby: '3.0'
+            redis_cluster: true
+          # opensearch-ruby 2.x requires ruby >= 2.4
+          - ruby: '2.3'
+            search: ['opensearch-ruby:2', 'opensearchproject/opensearch:2']
+          - ruby: '2.3'
+            search: ['opensearch-ruby:3', 'opensearchproject/opensearch:3']
+          # opensearch-ruby 3.x requires ruby >= 2.5
+          - ruby: '2.3'
+            search: ['opensearch-ruby:3', 'opensearchproject/opensearch:3']
+          - ruby: '2.4'
+            search: ['opensearch-ruby:3', 'opensearchproject/opensearch:3']
+          # elasticsearch 8.x requires ruby >= 2.5
+          - ruby: '2.3'
+            search: ['elasticsearch:8', 'elasticsearch:8.18.2']
+          - ruby: '2.4'
+            search: ['elasticsearch:8', 'elasticsearch:8.18.2']
+          # elasticsearch 9.x requires ruby >= 2.6
+          - ruby: '2.3'
+            search: ['elasticsearch:9', 'elasticsearch:9.0.2']
+          - ruby: '2.4'
+            search: ['elasticsearch:9', 'elasticsearch:9.0.2']
+          - ruby: '2.5'
+            search: ['elasticsearch:9', 'elasticsearch:9.0.2']
     services:
-      redis:
-        image: redis
-        ports:
-          - 6379:6379
       search:
         image: ${{ matrix.search[1] }}
         ports:
           - 9200:9200
         env:
           discovery.type: single-node
+          # Disable security for OpenSearch
           plugins.security.disabled: ${{ contains(matrix.search[1], 'opensearch') && 'true' || '' }}
+          # OpenSearch 2.12.0 removed the default admin password
+          OPENSEARCH_INITIAL_ADMIN_PASSWORD: M7$thunder9K # this doesn't need to be a secret
+          # Disable security for Elasticsearch 8.x and 9.x
+          xpack.security.enabled: ${{ contains(matrix.search[1], 'elasticsearch') && 'false' || '' }}
         options: >-
           --health-cmd="curl http://localhost:9200/_cluster/health"
           --health-interval=3s
@@ -56,6 +87,7 @@ jobs:
 
     env:
       REDIS_VERSION: ${{ matrix.redis }}
+      REDIS_CLUSTER: ${{ matrix.redis_cluster && 'true' || '' }}
       SEARCH_GEM: ${{ matrix.search[0] }}
 
     steps:
@@ -64,6 +96,14 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
+      - name: Start Redis (single instance)
+        if: ${{ !matrix.redis_cluster }}
+        run: |
+          docker run -d --name redis -p 6379:6379 redis
+      - name: Start Redis Cluster
+        if: ${{ matrix.redis_cluster }}
+        run: |
+          docker compose -f docker-compose.redis-cluster.yml up -d --wait
       - name: start MySQL
         run: sudo /etc/init.d/mysql start
       - run: bundle exec rspec --format doc
@@ -81,7 +121,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.7'
+          ruby-version: '3.4'
           bundler-cache: true
       - run: bundle exec rubocop
 
@@ -91,7 +131,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.7'
+          ruby-version: '3.4'
           bundler-cache: true
       - run: bin/yardoc --fail-on-warning
 
@@ -102,7 +142,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.7'
+          ruby-version: '3.4'
           bundler-cache: true
       - run: bin/check-version
 

--- a/Gemfile
+++ b/Gemfile
@@ -30,14 +30,21 @@ if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.6')
   gem 'simplecov-cobertura', '~> 2.1'
 end
 
-if ENV['REDIS_VERSION']
-  gem 'redis', "~> #{ENV['REDIS_VERSION']}"
+if (redis_version = ENV.fetch('REDIS_VERSION', nil))
+  gem 'redis', "~> #{redis_version}"
 end
 
-if ENV['SEARCH_GEM']
-  name, version = ENV['SEARCH_GEM'].split(':')
-  name = 'opensearch-ruby' if name == 'opensearch'
+if redis_version
+  if ENV.fetch('REDIS_CLUSTER', nil) == 'true'
+    gem 'redis-clustering', "~> #{redis_version}"
+  end
+elsif Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.7')
+  gem 'redis-clustering' # rubocop:disable Bundler/DuplicatedGem
+end
+
+if (search_gem = ENV.fetch('SEARCH_GEM', nil))
+  name, version = search_gem.split(':')
   gem name, "~> #{version}"
 else
-  gem 'opensearch-ruby', '~> 2.1'
+  gem 'opensearch-ruby'
 end

--- a/docker-compose.redis-cluster.yml
+++ b/docker-compose.redis-cluster.yml
@@ -1,0 +1,72 @@
+services:
+  redis-cluster-node-0:
+    image: docker.io/bitnami/redis-cluster:latest
+    volumes:
+      - redis-cluster_data-0:/bitnami/redis/data
+    environment:
+      - "ALLOW_EMPTY_PASSWORD=yes"
+      - "REDIS_NODES=redis-cluster-node-0 redis-cluster-node-1 redis-cluster-node-2 redis-cluster-node-3 redis-cluster-node-4 redis-cluster-node-5"
+
+  redis-cluster-node-1:
+    image: docker.io/bitnami/redis-cluster:latest
+    volumes:
+      - redis-cluster_data-1:/bitnami/redis/data
+    environment:
+      - "ALLOW_EMPTY_PASSWORD=yes"
+      - "REDIS_NODES=redis-cluster-node-0 redis-cluster-node-1 redis-cluster-node-2 redis-cluster-node-3 redis-cluster-node-4 redis-cluster-node-5"
+
+  redis-cluster-node-2:
+    image: docker.io/bitnami/redis-cluster:latest
+    volumes:
+      - redis-cluster_data-2:/bitnami/redis/data
+    environment:
+      - "ALLOW_EMPTY_PASSWORD=yes"
+      - "REDIS_NODES=redis-cluster-node-0 redis-cluster-node-1 redis-cluster-node-2 redis-cluster-node-3 redis-cluster-node-4 redis-cluster-node-5"
+
+  redis-cluster-node-3:
+    image: docker.io/bitnami/redis-cluster:latest
+    volumes:
+      - redis-cluster_data-3:/bitnami/redis/data
+    environment:
+      - "ALLOW_EMPTY_PASSWORD=yes"
+      - "REDIS_NODES=redis-cluster-node-0 redis-cluster-node-1 redis-cluster-node-2 redis-cluster-node-3 redis-cluster-node-4 redis-cluster-node-5"
+
+  redis-cluster-node-4:
+    image: docker.io/bitnami/redis-cluster:latest
+    volumes:
+      - redis-cluster_data-4:/bitnami/redis/data
+    environment:
+      - "ALLOW_EMPTY_PASSWORD=yes"
+      - "REDIS_NODES=redis-cluster-node-0 redis-cluster-node-1 redis-cluster-node-2 redis-cluster-node-3 redis-cluster-node-4 redis-cluster-node-5"
+
+  redis-cluster-node-5:
+    image: docker.io/bitnami/redis-cluster:latest
+    volumes:
+      - redis-cluster_data-5:/bitnami/redis/data
+    depends_on:
+      - redis-cluster-node-0
+      - redis-cluster-node-1
+      - redis-cluster-node-2
+      - redis-cluster-node-3
+      - redis-cluster-node-4
+    environment:
+      - "ALLOW_EMPTY_PASSWORD=yes"
+      - "REDIS_CLUSTER_REPLICAS=1"
+      - "REDIS_NODES=redis-cluster-node-0 redis-cluster-node-1 redis-cluster-node-2 redis-cluster-node-3 redis-cluster-node-4 redis-cluster-node-5"
+      - "REDIS_CLUSTER_CREATOR=yes"
+    ports:
+      - "6379:6379"
+
+volumes:
+  redis-cluster_data-0:
+    driver: local
+  redis-cluster_data-1:
+    driver: local
+  redis-cluster_data-2:
+    driver: local
+  redis-cluster_data-3:
+    driver: local
+  redis-cluster_data-4:
+    driver: local
+  redis-cluster_data-5:
+    driver: local

--- a/faulty.gemspec
+++ b/faulty.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   # Other non-essential development dependencies go in the Gemfile.
   spec.add_development_dependency 'connection_pool', '~> 2.0'
   spec.add_development_dependency 'json'
-  spec.add_development_dependency 'redis', '>= 3.0'
+  spec.add_development_dependency 'redis', '>= 4.0'
   spec.add_development_dependency 'rspec', '~> 3.8'
   spec.add_development_dependency 'timecop', '>= 0.9'
 end

--- a/lib/faulty/patch/elasticsearch.rb
+++ b/lib/faulty/patch/elasticsearch.rb
@@ -43,7 +43,12 @@ class Faulty
         ::OpenSearch
       else
         require 'elasticsearch'
-        ::Elasticsearch
+        if Gem.loaded_specs['elastic-transport']
+          require 'elastic-transport'
+          ::Elastic
+        else
+          ::Elasticsearch
+        end
       end
 
       # We will freeze this after adding the dynamic error classes
@@ -94,6 +99,14 @@ end
 
 if Gem.loaded_specs['opensearch-ruby']
   module OpenSearch
+    module Transport
+      class Client
+        prepend(Faulty::Patch::Elasticsearch)
+      end
+    end
+  end
+elsif Gem.loaded_specs['elastic-transport']
+  module Elastic
     module Transport
       class Client
         prepend(Faulty::Patch::Elasticsearch)

--- a/lib/faulty/patch/redis.rb
+++ b/lib/faulty/patch/redis.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 
 require 'redis'
+begin
+  require 'redis-clustering'
+rescue LoadError
+  nil
+end
 
 class Faulty
   module Patch

--- a/lib/faulty/storage/redis.rb
+++ b/lib/faulty/storage/redis.rb
@@ -293,7 +293,7 @@ class Faulty
       end
 
       def ckey(circuit_name, *parts)
-        key('circuit', circuit_name, *parts)
+        key('circuit', "{#{circuit_name}}", *parts)
       end
 
       # @return [String] The key for circuit options
@@ -323,7 +323,7 @@ class Faulty
 
       # Get the current key to add circuit names to
       def list_key
-        key('list', current_list_block)
+        key('list', "{#{current_list_block}}")
       end
 
       # Get all active circuit list keys
@@ -348,7 +348,7 @@ class Faulty
         num_blocks = (options.circuit_ttl.to_f / options.list_granularity).floor + 1
         start_block = current_list_block - num_blocks + 1
         num_blocks.times.map do |i|
-          key('list', start_block + i)
+          key('list', "{#{start_block + i}}")
         end
       end
 
@@ -372,11 +372,11 @@ class Faulty
       #   inside the block
       def watch_exec(key, old, &block)
         redis do |r|
-          r.watch(key) do
-            if old.include?(r.get(key))
-              r.multi(&block)
+          r.watch(key) do |c|
+            if old.include?(c.get(key))
+              c.multi(&block)
             else
-              r.unwatch
+              c.unwatch
               nil
             end
           end
@@ -424,11 +424,17 @@ class Faulty
         warn "Faulty error while checking client options: #{e.message}"
       end
 
-      def check_redis_options!
+      def check_redis_options! # rubocop:disable Metrics/MethodLength
         gte5 = ::Redis::VERSION.to_f >= 5
-        method = gte5 ? :config : :options
         ropts = redis do |r|
-          r.instance_variable_get(:@client).public_send(method)
+          if r.instance_of?(::Redis)
+            method = gte5 ? :config : :options
+            r._client.public_send(method)
+          elsif r.instance_of?(::Redis::Cluster)
+            r._client.config
+          else
+            raise TypeError, "Unsupported Redis client type: #{r.class}"
+          end
         end
 
         bad_timeouts = {}
@@ -445,7 +451,16 @@ class Faulty
           MSG
         end
 
-        gt1_retry = gte5 ? ropts.retry_connecting?(1, nil) : ropts[:reconnect_attempts] > 1
+        gt1_retry = redis do |r|
+          if r.instance_of?(::Redis)
+            gte5 ? ropts.retry_connecting?(1, nil) : ropts[:reconnect_attempts] > 1
+          elsif r.instance_of?(::Redis::Cluster)
+            ra = ropts.client_config[:reconnect_attempts]
+            (ra.is_a?(Array) && ra.length > 1) || ra > 1
+          else
+            raise TypeError, "Unsupported Redis client type: #{r.class}"
+          end
+        end
         if gt1_retry
           warn <<~MSG
             Faulty recommends setting Redis reconnect_attempts to <= 1 to

--- a/lib/faulty/storage/redis.rb
+++ b/lib/faulty/storage/redis.rb
@@ -293,7 +293,7 @@ class Faulty
       end
 
       def ckey(circuit_name, *parts)
-        key('circuit', "{#{circuit_name}}", *parts)
+        key('circuit', hashtag(circuit_name), *parts)
       end
 
       # @return [String] The key for circuit options
@@ -323,7 +323,7 @@ class Faulty
 
       # Get the current key to add circuit names to
       def list_key
-        key('list', "{#{current_list_block}}")
+        key('list', hashtag(current_list_block))
       end
 
       # Get all active circuit list keys
@@ -348,8 +348,12 @@ class Faulty
         num_blocks = (options.circuit_ttl.to_f / options.list_granularity).floor + 1
         start_block = current_list_block - num_blocks + 1
         num_blocks.times.map do |i|
-          key('list', "{#{start_block + i}}")
+          key('list', hashtag(start_block + i))
         end
+      end
+
+      def hashtag(part)
+        "{#{part}}"
       end
 
       # Get the block number for the current list set


### PR DESCRIPTION
Context in https://github.com/ParentSquare/faulty/issues/71
Additional context for @buildkite folks in https://github.com/buildkite/buildkite/pull/22829

This is a clean cherry pick of the following commits to my personal fork where I could freely iterate and run the CI workflow:
- https://github.com/joshuay03/faulty/commit/b77d25cf8776da56cecd07fc73b3b26b45cc60d5
- https://github.com/joshuay03/faulty/commit/53fcba1508620e3d5a802aa443f9d40e6dab1f9e
- https://github.com/joshuay03/faulty/commit/0f946b2a01a6e3398d3dd0f0ca269b428941e857
- https://github.com/joshuay03/faulty/commit/de531e7b2776ac7fee7e21c298080704e6e7d449

My goal is to merge this and point the bk/bk Gemfile to the ref temporarily so I can take my time upstreaming this work, which I've kicked off with https://github.com/ParentSquare/faulty/pull/72.

The spec suite was able to replicate the error I reported in https://github.com/ParentSquare/faulty/issues/71, as well as the cross-slot errors @pda came across, so I'm quite confident that if this builds green on non-head ruby versions we're good to go.